### PR TITLE
Test enhancements.

### DIFF
--- a/popcount_amd64_test.go
+++ b/popcount_amd64_test.go
@@ -27,3 +27,9 @@ func BenchmarkASM(b *testing.B) {
 		popcnt64ASM(0x123456789ABCDEF)
 	}
 }
+
+func BenchmarkASMIndirect(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		popcnt64(0x123456789ABCDEF)
+	}
+}

--- a/popcount_amd64_test.go
+++ b/popcount_amd64_test.go
@@ -1,0 +1,29 @@
+package popcount
+
+import (
+	"testing"
+	"testing/quick"
+)
+
+func TestPopCountCompare(t *testing.T) {
+	if !asm {
+		t.Skip()
+	}
+
+	for _, tc := range cases64 {
+		if popcnt64ASM(tc.x) != popcnt64Go(tc.x) {
+			t.Errorf("popcnt64ASM(%v) = %v; popcnt64Go(%v) = %d",
+				tc.x, popcnt64ASM(tc.x), tc.x, popcnt64Go(tc.x))
+		}
+	}
+
+	if err := quick.CheckEqual(popcnt64Go, popcnt64ASM, nil); err != nil {
+		t.Error(err)
+	}
+}
+
+func BenchmarkASM(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		popcnt64ASM(0x123456789ABCDEF)
+	}
+}

--- a/popcount_test.go
+++ b/popcount_test.go
@@ -1,8 +1,6 @@
 package popcount
 
-import (
-	"testing"
-)
+import "testing"
 
 type (
 	testCase64 struct {
@@ -53,5 +51,11 @@ func TestPopCountSlice(t *testing.T) {
 		if count != tc.n {
 			t.Error("Expected", tc.n, "got", count)
 		}
+	}
+}
+
+func BenchmarkGeneric(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		popcnt64Go(0x123456789ABCDEF)
 	}
 }


### PR DESCRIPTION
Test the asm and go functions return the same values.

Also, benchmark:

BenchmarkASM-4      1000000000           2.26 ns/op
BenchmarkGeneric-4  500000000            3.11 ns/op

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hideo55/go-popcount/1)

<!-- Reviewable:end -->
