### PR TITLE
Avoid condition in amd64 popcount.

### DIFF
--- a/popcount_amd64.go
+++ b/popcount_amd64.go
@@ -5,11 +5,10 @@ package popcount
 func havePOPCNT() bool
 func popcnt64ASM(x uint64) uint64
 
-var asm = havePOPCNT()
+var popcnt64 = popcnt64ASM
 
-func popcnt64(x uint64) uint64 {
-	if asm {
-		return popcnt64ASM(x)
+func init() {
+	if !havePOPCNT() {
+		popcnt64 = popcnt64Go
 	}
-	return popcnt64Go(x)
 }

--- a/popcount_amd64_test.go
+++ b/popcount_amd64_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestPopCountCompare(t *testing.T) {
-	if !asm {
+	if !havePOPCNT() {
 		t.Skip()
 	}
 


### PR DESCRIPTION
This makes it not possible to inline, but does show that it benches
faster:

```
BenchmarkASM-4             2.29          2.64          +15.28%
BenchmarkASMIndirect-4     4.23          3.04          -28.13%
BenchmarkGeneric-4         3.25          3.18          -2.15%
```

The numbers are small, so things fluctuate a bit (as you can see in the
results for asm and generic on this 15s bench), but most importantly,
the asm version with conditional was typically slower than the pure go
version.  This new variant is still slower than calling the asm version
directly, but is at least typically faster than the generic version.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hideo55/go-popcount/2)

<!-- Reviewable:end -->
